### PR TITLE
Increase minimum disk space requirement from 500MB to 600MB in getpve…

### DIFF
--- a/getpvelogs.sh
+++ b/getpvelogs.sh
@@ -54,7 +54,7 @@ shopt -s lastpipe
 
 # ---------- Constants ----------
 readonly VERSION="4.0.7"
-readonly MIN_DISK_SPACE_MB=500
+readonly MIN_DISK_SPACE_MB=600
 readonly CMD_TIMEOUT=60
 
 # ---------- Global variables ----------


### PR DESCRIPTION
…logs.sh to ensure adequate resources for logging operations.